### PR TITLE
Scale down index images

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -19,11 +19,13 @@
                                 {{ .PublishDate.Format "2006-01-02" }}
                             </div>
                         </div>
-                        {{ $featured_image := .Params.featured_image }}
+                        {{ $featured_image := .Params.featured_image | default "" }}
+                        {{ $featured_image = .Resources.GetMatch $featured_image}}
                         {{ if $featured_image }}
+                            {{ $featured_image = $featured_image.Fill "230x120 q95" }}
                             <div class="post-item-image-wrapper">
                             <div class="post-item-image"
-                                 style="background-image: url('{{$featured_image | relLangURL }}')"></div>
+                                 style="background-image: url('{{ $featured_image.Permalink | relLangURL }}')"></div>
                             </div>
                         {{ end }}
                     </div>


### PR DESCRIPTION
Index miniature images are 230x120px. No reason to use full resolution images. It speeds the page a lot if using high res for `featured_image`.